### PR TITLE
Make BeaconComponent simpler

### DIFF
--- a/src/main/java/com/lgmrszd/anshar/beacon/BeaconComponent.java
+++ b/src/main/java/com/lgmrszd/anshar/beacon/BeaconComponent.java
@@ -98,6 +98,7 @@ public class BeaconComponent implements IBeaconComponent {
 
     private void activate() {
         pyramidFrequency = rescanPyramid();
+        if (!pyramidFrequency.isValid()) return;
         updateNetwork();
         active = true;
     }

--- a/src/main/java/com/lgmrszd/anshar/beacon/DebugEvents.java
+++ b/src/main/java/com/lgmrszd/anshar/beacon/DebugEvents.java
@@ -30,12 +30,12 @@ public final class DebugEvents {
             BlockEntity be = world.getBlockEntity(pos);
             if (!(be instanceof BeaconBlockEntity bbe)) return ActionResult.PASS;
             IBeaconComponent beacComp = IBeaconComponent.KEY.get(bbe);
-            if (beacComp.getFrequencyID().isValid())
+            if (beacComp.getEffectiveFrequencyID().isValid())
                 player.sendMessage(Text.literal(
                         String.format(
                                 "Beacon pos: %s, frequency: %s, network: %s",
                                 pos,
-                                beacComp.getFrequencyID().hashCode(),
+                                beacComp.getEffectiveFrequencyID().hashCode(),
                                 beacComp.getFrequencyNetwork()
                                         .map(frequencyNetwork -> frequencyNetwork.getId().toString())
                                         .orElse("None")
@@ -71,9 +71,9 @@ public final class DebugEvents {
                             bbe -> {
                                 IBeaconComponent beacComp = IBeaconComponent.KEY.get(bbe);
                                 BlockPos pos = bbe.getPos();
-                                if (beacComp.getFrequencyID().isValid())
+                                if (beacComp.getEffectiveFrequencyID().isValid())
                                     player.sendMessage(Text.literal(
-                                            String.format("Nearest beacon pos: %s, frequency: %s", pos, beacComp.getFrequencyID().hashCode())
+                                            String.format("Nearest beacon pos: %s, frequency: %s", pos, beacComp.getEffectiveFrequencyID().hashCode())
                                     ));
                                 else {
                                     player.sendMessage(Text.literal(

--- a/src/main/java/com/lgmrszd/anshar/beacon/IBeaconComponent.java
+++ b/src/main/java/com/lgmrszd/anshar/beacon/IBeaconComponent.java
@@ -9,7 +9,6 @@ import dev.onyxstudios.cca.api.v3.component.ComponentKey;
 import dev.onyxstudios.cca.api.v3.component.ComponentRegistry;
 import dev.onyxstudios.cca.api.v3.component.tick.ServerTickingComponent;
 import net.minecraft.text.Text;
-import net.minecraft.util.DyeColor;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 
@@ -22,9 +21,9 @@ public interface IBeaconComponent extends ServerTickingComponent {
 
 //    void rescanPyramid();
 
-    void activate();
+    boolean isValid();
     boolean isActive();
-    IFrequencyIdentifier getFrequencyID();
+    IFrequencyIdentifier getEffectiveFrequencyID();
 
     Optional<FrequencyNetwork> getFrequencyNetwork();
 

--- a/src/main/java/com/lgmrszd/anshar/frequency/NetworkManagerComponent.java
+++ b/src/main/java/com/lgmrszd/anshar/frequency/NetworkManagerComponent.java
@@ -103,14 +103,18 @@ public class NetworkManagerComponent implements Component {
         ) return;
         BlockPos beaconPos = beaconComponent.getBeaconPos();
         // Remove beacon from the old network if present
-        beaconComponent.getFrequencyNetwork().ifPresent(frequencyNetwork -> {
-            if (!frequencyNetwork.removeBeacon(beaconPos)) {
-                LOGGER.warn(String.format(
-                        "ANSHAR WARNING: Tried to remove beacon %s from network %s but it's already not there",
-                        beaconPos,
-                        frequencyNetwork
-                ));
-            }
+        // TODO: Just to make it safe for now
+//        beaconComponent.getFrequencyNetwork().ifPresent(frequencyNetwork -> {
+//            if (!frequencyNetwork.removeBeacon(beaconPos)) {
+//                LOGGER.warn(String.format(
+//                        "ANSHAR WARNING: Tried to remove beacon %s from network %s but it's already not there",
+//                        beaconPos,
+//                        frequencyNetwork
+//                ));
+//            }
+//        });
+        getNetworks().forEach(frequencyNetwork -> {
+            frequencyNetwork.removeBeacon(beaconPos);
         });
         // Add beacon to the new network
         if (frequencyIdentifier.isValid()) {


### PR DESCRIPTION
Made beacon component a lot more simpler now since we don't actually need to have it always active after chunk is unloaded and loaded again.

BeaconComponent now tracks its current state (`active`). It it also capable of checking whenever it is valid or not (directly taking it from BeaconBlockEntity). Beacon is active when the pyramid is present and the sky is visible (beam is here).

Whenever BeaconComponent detects that is valid, but not active, it will attempt to activate. Other way around, whenever it detects that it is not valid but still active, it will attempt to deactivate. If valid and active, it will keep checking pyramid every so often for the frequency change.

We also no longer store frequency identifier with the Beacon Component because why would we need to in the first place (unloaded beacons stored in the network and loaded ones calculate it anyway)

NetworkComponent might need additional rewriting to be more efficient: since newly-loaded beacons are not guaranteed to have same frequency as before unloading, we're trying to remove it from every Network